### PR TITLE
Add wind_up_retry_number property and logic to give up if set and exceeded

### DIFF
--- a/Source/ACE.Server/Entity/WindupParams.cs
+++ b/Source/ACE.Server/Entity/WindupParams.cs
@@ -5,12 +5,14 @@ namespace ACE.Server.Entity
         public uint TargetGuid;
         public uint SpellId;
         public bool BuiltInSpell;
+        public long TurnTries;
 
         public WindupParams(uint targetGuid, uint spellId, bool builtInSpell)
         {
             TargetGuid = targetGuid;
             SpellId = spellId;
             BuiltInSpell = builtInSpell;
+            TurnTries = 0;
         }
 
         public override string ToString()

--- a/Source/ACE.Server/Managers/PropertyManager.cs
+++ b/Source/ACE.Server/Managers/PropertyManager.cs
@@ -608,7 +608,8 @@ namespace ACE.Server.Managers
                 ("player_save_interval", new Property<long>(300, "the number of seconds between automatic player saves")),
                 ("rares_max_days_between", new Property<long>(45, "for rares_real_time_v2: the maximum number of days a player can go before a rare is generated on rare eligible creature kills")),
                 ("rares_max_seconds_between", new Property<long>(5256000, "for rares_real_time: the maximum number of seconds a player can go before a second chance at a rare is allowed on rare eligible creature kills that did not generate a rare")),
-                ("teleport_visibility_fix", new Property<long>(0, "Fixes some possible issues with invisible players and mobs. 0 = default / disabled, 1 = players only, 2 = creatures, 3 = all world objects"))
+                ("teleport_visibility_fix", new Property<long>(0, "Fixes some possible issues with invisible players and mobs. 0 = default / disabled, 1 = players only, 2 = creatures, 3 = all world objects")),
+                ("windup_turn_retry_number", new Property<long>(0, "Fixes turning forever during windup. 0 = default / disabled, 1 = retry one time, 2 = retry two times, ..."))
                 );
 
         public static readonly ReadOnlyDictionary<string, Property<double>> DefaultDoubleProperties =

--- a/Source/ACE.Server/WorldObjects/Player_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Magic.cs
@@ -210,7 +210,31 @@ namespace ACE.Server.WorldObjects
             {
                 // restart turn if required
                 if (PhysicsObj.MovementManager.MotionInterpreter.InterpretedState.TurnCommand == 0)
-                    TurnTo_Magic(target);
+                {
+                    var windUpRetryLimit = PropertyManager.GetLong("windup_turn_retry_number").Item;
+                    // Console.WriteLine($"windUpRetryLimit: {windUpRetryLimit}");
+                    if (windUpRetryLimit > 0)
+                    {
+                        if (windupParams.TurnTries < windUpRetryLimit)
+                        {
+                            windupParams.TurnTries += 1;
+                            // Console.WriteLine($"{Name} turn to in DoWindup try #{windupParams.TurnTries}/{windUpRetryLimit}");
+                            TurnTo_Magic(target);
+                        }
+                        else
+                        {
+                            // give up after trying to correct angle a few times..
+                            // Console.WriteLine($"{Name} turn to in DoWindup giving up..");
+                            MagicState.OnCastDone();
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        // If windup_turn_retry_number property is 0 try forever like before.
+                        TurnTo_Magic(target);
+                    }
+                }
                 else
                     MagicState.PendingTurnRelease = true;
             }


### PR DESCRIPTION
Adds wind_up_retry_number server property to limit the amount of time a started cast will try to adjust the angle to face target.
If set the 0 it will try forever (no change), 3 will attempt to turn the player to the target and begin the cast 3 times, etc.

video showing how the current code acts compared to when limited.
https://www.youtube.com/watch?v=s_z6RumoqU0